### PR TITLE
include registerMethods examples in generated output.

### DIFF
--- a/generators/app/templates/codemod.js
+++ b/generators/app/templates/codemod.js
@@ -2,19 +2,33 @@
 
 module.exports = function <%= camelName %>(file, api) {
 	var j = api.jscodeshift;
-	var ast = j(file.source);
 
-	ast.find(j.CallExpression, {
-		callee: {
-			type: 'Identifier',
-			name: 'foo'
+	// Adding a method to all collections
+	j.registerMethods({
+		findCalls: function(name) {
+			return this.find(j.CallExpression, {
+				callee: {
+					type: 'Identifier',
+					name: name
+				}
+			});
 		}
-	}).forEach(function (p) {
-		p.get('callee').replace(j.identifier('bar'));
 	});
 
-	return ast.toSource({
-		useTabs: true,
-		quote: 'single'
-	});
+	// Adding a method to all CallExpressions
+	j.registerMethods({
+		renameCallee: function (name) {
+			return this.forEach(function (path) {
+				path.get('callee').replace(j.identifier(name))
+			});
+		}
+	}, j.CallExpression);
+
+	return j(file.source)
+		.findCalls('foo')
+		.renameCallee('bar')
+		.toSource({
+			useTabs: true,
+			quote: 'single'
+		});
 };


### PR DESCRIPTION
It's a bit more verbose, but provides some helpful reminders about the API.
